### PR TITLE
feat: Geolonia Embed 経由でのみ使用可能に制限

### DIFF
--- a/src/hooks/useGeoloniaMap.ts
+++ b/src/hooks/useGeoloniaMap.ts
@@ -6,6 +6,7 @@ declare global {
   interface Window {
     geolonia?: {
       Map: new (options: maplibregl.MapOptions) => maplibregl.Map
+      version?: string
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ export { canDeleteVertex, applyVertexDelete } from './lib/vertex-helpers'
 // Geolonia integration
 export { useGeoloniaMap } from './hooks/useGeoloniaMap'
 export type { GeoloniaMapSettings } from './hooks/useGeoloniaMap'
-export { assertGeolonia, GeoloniaNotFoundError } from './lib/assert-geolonia'
+export { assertGeolonia, GeoloniaNotFoundError, GeoloniaEmbedNotDetectedError, hasEmbedScript } from './lib/assert-geolonia'
 export { GeoloniaIcon } from './components/GeoloniaIcon'
 
 // Types

--- a/src/lib/__tests__/assert-geolonia.test.ts
+++ b/src/lib/__tests__/assert-geolonia.test.ts
@@ -15,8 +15,8 @@ function addEmbedScript(src = 'https://cdn.geolonia.com/v1/embed?geolonia-api-ke
 }
 
 function removeAllEmbedScripts() {
-  document.querySelectorAll('script[data-testid="embed-test"]').forEach((s) => s.remove())
-  document.querySelectorAll('script[data-testid="geolonia-embed"]').forEach((s) => s.remove())
+  document.querySelectorAll('script[data-testid="embed-test"]').forEach((s) => { s.remove() })
+  document.querySelectorAll('script[data-testid="geolonia-embed"]').forEach((s) => { s.remove() })
 }
 
 describe('GeoloniaEmbedNotDetectedError', () => {

--- a/src/lib/__tests__/assert-geolonia.test.ts
+++ b/src/lib/__tests__/assert-geolonia.test.ts
@@ -1,34 +1,137 @@
-import { describe, it, expect, vi } from 'vitest'
-import { assertGeolonia, GeoloniaNotFoundError } from '../assert-geolonia'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  assertGeolonia,
+  GeoloniaNotFoundError,
+  GeoloniaEmbedNotDetectedError,
+  hasEmbedScript,
+} from '../assert-geolonia'
 
-describe('assertGeolonia', () => {
-  it('does not throw when window.geolonia.Map exists', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    window.geolonia = { Map: vi.fn() } as any
-    expect(() => assertGeolonia()).not.toThrow()
+function addEmbedScript(src = 'https://cdn.geolonia.com/v1/embed?geolonia-api-key=YOUR-API-KEY') {
+  const script = document.createElement('script')
+  script.src = src
+  script.setAttribute('data-testid', 'embed-test')
+  document.head.appendChild(script)
+  return script
+}
+
+function removeAllEmbedScripts() {
+  document.querySelectorAll('script[data-testid="embed-test"]').forEach((s) => s.remove())
+  document.querySelectorAll('script[data-testid="geolonia-embed"]').forEach((s) => s.remove())
+}
+
+describe('GeoloniaEmbedNotDetectedError', () => {
+  it('has correct name and message', () => {
+    const err = new GeoloniaEmbedNotDetectedError()
+    expect(err.name).toBe('GeoloniaEmbedNotDetectedError')
+    expect(err).toBeInstanceOf(Error)
+    expect(err.message).toContain('スクリプトタグが見つかりません')
+    expect(err.message).toContain('cdn.geolonia.com/v1/embed')
   })
+})
 
-  it('throws GeoloniaNotFoundError when window.geolonia is undefined', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    delete (window as any).geolonia
-    expect(() => assertGeolonia()).toThrow(GeoloniaNotFoundError)
-  })
-
-  it('throws GeoloniaNotFoundError when window.geolonia.Map is undefined', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window as any).geolonia = {}
-    expect(() => assertGeolonia()).toThrow(GeoloniaNotFoundError)
-  })
-
-  it('error message includes script tag instruction', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    delete (window as any).geolonia
-    expect(() => assertGeolonia()).toThrow('Geolonia Maps Embed API')
-  })
-
-  it('error name is GeoloniaNotFoundError', () => {
+describe('GeoloniaNotFoundError', () => {
+  it('has correct name and message', () => {
     const err = new GeoloniaNotFoundError()
     expect(err.name).toBe('GeoloniaNotFoundError')
     expect(err).toBeInstanceOf(Error)
+    expect(err.message).toContain('Map コンストラクタが見つかりません')
+  })
+})
+
+describe('hasEmbedScript', () => {
+  afterEach(() => {
+    removeAllEmbedScripts()
+  })
+
+  it('returns true when Embed script tag with CDN URL exists', () => {
+    addEmbedScript()
+    expect(hasEmbedScript()).toBe(true)
+  })
+
+  it('returns true with different query params', () => {
+    addEmbedScript('https://cdn.geolonia.com/v1/embed?geolonia-api-key=DIFFERENT-KEY&lang=ja')
+    expect(hasEmbedScript()).toBe(true)
+  })
+
+  it('returns false when no Embed script tag exists', () => {
+    removeAllEmbedScripts()
+    expect(hasEmbedScript()).toBe(false)
+  })
+
+  it('returns false when script tags exist but none match CDN pattern', () => {
+    removeAllEmbedScripts()
+    const script = document.createElement('script')
+    script.src = 'https://example.com/some-other-script.js'
+    script.setAttribute('data-testid', 'embed-test')
+    document.head.appendChild(script)
+    expect(hasEmbedScript()).toBe(false)
+  })
+})
+
+describe('assertGeolonia', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+    removeAllEmbedScripts()
+  })
+
+  it('does not throw when Embed script tag present and Map exists', () => {
+    addEmbedScript()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(window as any).geolonia = { Map: vi.fn() }
+    expect(() => assertGeolonia()).not.toThrow()
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('throws GeoloniaEmbedNotDetectedError when Embed script tag is missing and Map is missing', () => {
+    removeAllEmbedScripts()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).geolonia
+    expect(() => assertGeolonia()).toThrow(GeoloniaEmbedNotDetectedError)
+  })
+
+  it('throws GeoloniaNotFoundError when Embed script tag present but Map is not ready', () => {
+    addEmbedScript()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(window as any).geolonia = {}
+    expect(() => assertGeolonia()).toThrow(GeoloniaNotFoundError)
+  })
+
+  it('throws GeoloniaNotFoundError when Embed script tag present and geolonia is undefined', () => {
+    addEmbedScript()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).geolonia
+    expect(() => assertGeolonia()).toThrow(GeoloniaNotFoundError)
+  })
+
+  it('warns but does not throw when Map exists without Embed script tag (dev scenario)', () => {
+    removeAllEmbedScripts()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(window as any).geolonia = { Map: vi.fn() }
+    expect(() => assertGeolonia()).not.toThrow()
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Embed API のスクリプトタグが検出されませんでした'),
+    )
+  })
+
+  it('works with different CDN URL patterns (with query params)', () => {
+    addEmbedScript('https://cdn.geolonia.com/v1/embed?geolonia-api-key=TEST&lang=en')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(window as any).geolonia = { Map: vi.fn() }
+    expect(() => assertGeolonia()).not.toThrow()
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('throws GeoloniaEmbedNotDetectedError when geolonia.Map is undefined and no embed script', () => {
+    removeAllEmbedScripts()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(window as any).geolonia = {}
+    expect(() => assertGeolonia()).toThrow(GeoloniaEmbedNotDetectedError)
   })
 })

--- a/src/lib/assert-geolonia.ts
+++ b/src/lib/assert-geolonia.ts
@@ -1,5 +1,3 @@
-const EMBED_CDN_PATTERN = 'cdn.geolonia.com/v1/embed'
-
 export class GeoloniaEmbedNotDetectedError extends Error {
   constructor() {
     super(
@@ -28,8 +26,15 @@ export class GeoloniaNotFoundError extends Error {
 export function hasEmbedScript(): boolean {
   const scripts = document.querySelectorAll('script[src]')
   for (const script of scripts) {
-    if (script.getAttribute('src')?.includes(EMBED_CDN_PATTERN)) {
-      return true
+    const src = script.getAttribute('src')
+    if (!src) continue
+    try {
+      const url = new URL(src, document.baseURI)
+      if (url.hostname === 'cdn.geolonia.com' && url.pathname === '/v1/embed') {
+        return true
+      }
+    } catch {
+      // ignore invalid URL
     }
   }
   return false
@@ -50,7 +55,7 @@ export function hasEmbedScript(): boolean {
  */
 export function assertGeolonia(): void {
   const embedDetected = hasEmbedScript()
-  const mapExists = !!window.geolonia?.Map
+  const mapExists = typeof window.geolonia?.Map === 'function'
 
   if (mapExists) {
     if (!embedDetected) {

--- a/src/lib/assert-geolonia.ts
+++ b/src/lib/assert-geolonia.ts
@@ -1,19 +1,71 @@
+const EMBED_CDN_PATTERN = 'cdn.geolonia.com/v1/embed'
+
+export class GeoloniaEmbedNotDetectedError extends Error {
+  constructor() {
+    super(
+      'Geolonia Embed API のスクリプトタグが見つかりません。\n' +
+      '以下のスクリプトタグをHTMLに追加してください:\n' +
+      '<script src="https://cdn.geolonia.com/v1/embed?geolonia-api-key=YOUR-API-KEY"></script>',
+    )
+    this.name = 'GeoloniaEmbedNotDetectedError'
+  }
+}
+
 export class GeoloniaNotFoundError extends Error {
   constructor() {
     super(
-      '@geolonia/drawing-engine requires the Geolonia Maps Embed API. ' +
-      'Please load the script: <script src="https://cdn.geolonia.com/v1/embed?geolonia-api-key=YOUR-API-KEY"></script>',
+      'Geolonia Maps の Map コンストラクタが見つかりません。\n' +
+      'Embed API スクリプトの読み込みが完了していない可能性があります。\n' +
+      'スクリプトの読み込み完了後に実行してください。',
     )
     this.name = 'GeoloniaNotFoundError'
   }
 }
 
 /**
- * Asserts that `window.geolonia.Map` exists at runtime.
- * Throws `GeoloniaNotFoundError` if the Geolonia Embed API is not loaded.
+ * Checks whether an Embed script tag with `cdn.geolonia.com/v1/embed` exists in the document.
+ */
+export function hasEmbedScript(): boolean {
+  const scripts = document.querySelectorAll('script[src]')
+  for (const script of scripts) {
+    if (script.getAttribute('src')?.includes(EMBED_CDN_PATTERN)) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * Asserts that the Geolonia Embed API is properly loaded.
+ *
+ * 1. Verifies that a `<script>` tag referencing the Embed CDN exists.
+ * 2. Verifies that `window.geolonia.Map` is available.
+ *
+ * If the Map constructor exists but no Embed script tag is found, a warning is
+ * logged instead of throwing — this supports development scenarios where the
+ * Map constructor is provided without the standard Embed script tag.
+ *
+ * @throws {GeoloniaEmbedNotDetectedError} if no Embed script tag is found and Map is unavailable.
+ * @throws {GeoloniaNotFoundError} if the Embed script tag exists but Map is not ready.
  */
 export function assertGeolonia(): void {
-  if (!window.geolonia?.Map) {
+  const embedDetected = hasEmbedScript()
+  const mapExists = !!window.geolonia?.Map
+
+  if (mapExists) {
+    if (!embedDetected) {
+      console.warn(
+        '[@geolonia/drawing-engine] window.geolonia.Map は利用可能ですが、' +
+        'Embed API のスクリプトタグが検出されませんでした。' +
+        '本番環境では Geolonia Embed API 経由でご利用ください。',
+      )
+    }
+    return
+  }
+
+  // Map does not exist
+  if (embedDetected) {
     throw new GeoloniaNotFoundError()
   }
+  throw new GeoloniaEmbedNotDetectedError()
 }

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -2,6 +2,12 @@ import { cleanup } from '@testing-library/react'
 import { afterEach, beforeEach, vi } from 'vitest'
 
 beforeEach(() => {
+  // Mock Embed script tag
+  const script = document.createElement('script')
+  script.src = 'https://cdn.geolonia.com/v1/embed?geolonia-api-key=YOUR-API-KEY'
+  script.setAttribute('data-testid', 'geolonia-embed')
+  document.head.appendChild(script)
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ;(window as any).geolonia = { Map: vi.fn() }
 })
@@ -10,4 +16,8 @@ afterEach(() => {
   cleanup()
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   delete (window as any).geolonia
+
+  // Remove mock Embed script tags
+  const scripts = document.querySelectorAll('script[data-testid="geolonia-embed"]')
+  scripts.forEach((s) => s.remove())
 })

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -19,5 +19,5 @@ afterEach(() => {
 
   // Remove mock Embed script tags
   const scripts = document.querySelectorAll('script[data-testid="geolonia-embed"]')
-  scripts.forEach((s) => s.remove())
+  scripts.forEach((s) => { s.remove() })
 })


### PR DESCRIPTION
## Summary

- `assertGeolonia()` を強化し、Geolonia Embed API の `<script>` タグの存在を検出するチェックを追加
- Embed スクリプトなし + Map なし → `GeoloniaEmbedNotDetectedError` をスロー
- Embed スクリプトあり + Map なし → `GeoloniaNotFoundError` をスロー（読み込み未完了）
- Embed スクリプトなし + Map あり → 警告のみ（開発環境対応）

## Changes

| ファイル | 変更内容 |
|---|---|
| `src/lib/assert-geolonia.ts` | `hasEmbedScript()`, `GeoloniaEmbedNotDetectedError` 追加、`assertGeolonia()` ロジック強化 |
| `src/lib/__tests__/assert-geolonia.test.ts` | テストを大幅拡充（34行 → 137行） |
| `src/hooks/useGeoloniaMap.ts` | `geolonia.version` 型定義追加 |
| `src/index.ts` | 新規エクスポート追加（`GeoloniaEmbedNotDetectedError`, `hasEmbedScript`） |
| `vitest.setup.ts` | テスト環境で Embed スクリプトタグのモック追加 |

## 影響範囲

- `assertGeolonia()` の挙動が変わる：Embed スクリプトタグがない場合、エラーの種類が `GeoloniaNotFoundError` → `GeoloniaEmbedNotDetectedError` に変わる
- 開発環境で `window.geolonia.Map` を直接セットしている場合は警告のみでブロックしない

## Test plan

- [x] `src/lib/__tests__/assert-geolonia.test.ts` で全パターンをカバー
- [ ] `npm run test:coverage` でカバレッジ 100% を確認
- [ ] `npm run build` でビルド成功を確認
- [ ] `npm run lint` でリント通過を確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 埋め込みスクリプトの検出機能を公開し、存在に応じた判定が可能になりました。
  * スクリプト未検出時の専用エラーを追加し、状況に応じて警告や別エラーを返す挙動に改善しました。

* **テスト**
  * 埋め込みスクリプト検出と各種エラーハンドリングのテストカバレッジを拡張しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->