### PR TITLE
feat: GeoloniaIcon を公式シンボルロゴに置き換え

### DIFF
--- a/src/components/GeoloniaIcon.tsx
+++ b/src/components/GeoloniaIcon.tsx
@@ -1,25 +1,17 @@
 export function GeoloniaIcon() {
   return (
     <svg
-      viewBox="0 0 24 24"
+      viewBox="0 0 136.063 136.063"
       width="24"
       height="24"
-      fill="none"
       aria-label="Powered by Geolonia"
       role="img"
     >
-      <circle cx="12" cy="12" r="11" fill="#2563eb" />
-      <text
-        x="12"
-        y="16.5"
-        textAnchor="middle"
-        fill="#fff"
-        fontSize="14"
-        fontWeight="bold"
-        fontFamily="system-ui, sans-serif"
-      >
-        G
-      </text>
+      <path fill="#EE730D" d="M0,87.165c0,2.598,0,4.797,0,6.378c0,23.483,19.037,42.52,42.52,42.52c1.399,0,3.285,0,5.498,0l48.898-48.897H0z" />
+      <path fill="#EB5C0C" d="M54.029,136.063c13.421,0,32.482,0,39.514,0c23.483,0,42.52-19.036,42.52-42.52c0-1.581,0-3.78,0-6.378h-33.136L54.029,136.063z" />
+      <path fill="#E84130" d="M48.898,0C46.3,0,44.101,0,42.52,0C19.037,0,0,19.037,0,42.52c0,7.186,0,26.939,0,40.394h48.898V0z" />
+      <path fill="#FAC03D" d="M102.927,82.913h33.136c0-13.454,0-33.208,0-40.394c0-23.483-19.037-42.52-42.52-42.52C86.357,0,66.604,0,53.15,0v33.136L102.927,82.913z" />
+      <polygon fill="#F39813" points="53.15,82.913 96.916,82.913 53.15,39.147" />
     </svg>
   )
 }

--- a/src/components/__tests__/GeoloniaIcon.test.tsx
+++ b/src/components/__tests__/GeoloniaIcon.test.tsx
@@ -10,11 +10,24 @@ describe('GeoloniaIcon', () => {
     expect(svg.tagName.toLowerCase()).toBe('svg')
   })
 
-  it('contains the "G" text element', () => {
+  it('contains the Geolonia symbol paths', () => {
     const { container } = render(<GeoloniaIcon />)
-    const text = container.querySelector('text')
-    expect(text).not.toBeNull()
-    expect(text!.textContent).toBe('G')
+    const paths = container.querySelectorAll('path')
+    expect(paths.length).toBe(4)
+    const polygon = container.querySelector('polygon')
+    expect(polygon).not.toBeNull()
+  })
+
+  it('uses the correct brand colors', () => {
+    const { container } = render(<GeoloniaIcon />)
+    const paths = container.querySelectorAll('path')
+    const fills = Array.from(paths).map((p) => p.getAttribute('fill'))
+    expect(fills).toContain('#EE730D')
+    expect(fills).toContain('#EB5C0C')
+    expect(fills).toContain('#E84130')
+    expect(fills).toContain('#FAC03D')
+    const polygon = container.querySelector('polygon')
+    expect(polygon!.getAttribute('fill')).toBe('#F39813')
   })
 
   it('has 24x24 dimensions', () => {
@@ -22,5 +35,11 @@ describe('GeoloniaIcon', () => {
     const svg = screen.getByRole('img', { name: 'Powered by Geolonia' })
     expect(svg.getAttribute('width')).toBe('24')
     expect(svg.getAttribute('height')).toBe('24')
+  })
+
+  it('has the correct viewBox for the symbol', () => {
+    render(<GeoloniaIcon />)
+    const svg = screen.getByRole('img', { name: 'Powered by Geolonia' })
+    expect(svg.getAttribute('viewBox')).toBe('0 0 136.063 136.063')
   })
 })


### PR DESCRIPTION
## Summary

- パネルのブランディングアイコン（`GeoloniaIcon` コンポーネント）を、プレースホルダーの青丸 "G" テキストから **Geolonia 公式シンボルマーク**（4色ジオメトリックロゴ）に置き換え
- `symbol.svg` からシンボル部分（`viewBox 0 0 136.063 136.063`）を抽出し、インライン SVG として実装
- テストを更新：`<text>G</text>` の検証から、path/polygon 要素数・ブランドカラー（`#EE730D`, `#EB5C0C`, `#E84130`, `#FAC03D`, `#F39813`）・viewBox の検証に変更

## 変更ファイル

| ファイル | 変更内容 |
|----------|----------|
| `src/components/GeoloniaIcon.tsx` | SVG を公式シンボルロゴに差し替え |
| `src/components/__tests__/GeoloniaIcon.test.tsx` | テストをシンボルロゴに合わせて更新（5テスト） |

## 影響範囲

- `DrawControlPanel` のブランディングセクションに表示されるアイコンが変わる
- 他のコンポーネントへの影響なし（`GeoloniaIcon` のインターフェース変更なし）

## Test plan

- [x] `npm run lint` — ESLint 通過
- [x] `npm run test:coverage` — 全 286 テスト通過、カバレッジ 100%
- [x] `npm run build` — ビルド成功

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * Geolonia アイコンをリデザイン。シンプルな円形バッジからマルチカラーの詳細なロゴに更新されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->