### PR TITLE
feat: HTML から利用するサンプルページの作成とソースコード閲覧ボタンの追加 (#20)

### DIFF
--- a/preview/home.html
+++ b/preview/home.html
@@ -69,6 +69,10 @@
         <h2>React Demo</h2>
         <span>React hooks + コンポーネント</span>
       </a>
+      <a class="demo-card" href="./html-sample.html">
+        <h2>HTML Sample</h2>
+        <span>HTML + script タグで利用するサンプル（ソースコード閲覧可）</span>
+      </a>
     </div>
   </div>
 </body>

--- a/preview/html-sample.html
+++ b/preview/html-sample.html
@@ -1,0 +1,258 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Drawing Engine - HTML Sample</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+    #map { width: 100%; height: 100vh; }
+
+    .view-source-button {
+      position: fixed;
+      bottom: 1.5rem;
+      right: 1.5rem;
+      z-index: 1000;
+      padding: 0.625rem 1.25rem;
+      background: #2563eb;
+      color: #fff;
+      border: none;
+      border-radius: 8px;
+      font-size: 0.875rem;
+      font-weight: 600;
+      cursor: pointer;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+      transition: background 0.15s ease;
+    }
+    .view-source-button:hover { background: #1d4ed8; }
+    .view-source-button:focus-visible {
+      outline: 2px solid #2563eb;
+      outline-offset: 2px;
+    }
+
+    .source-dialog {
+      border: none;
+      border-radius: 12px;
+      padding: 0;
+      max-width: 720px;
+      width: 90vw;
+      max-height: 80vh;
+      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25);
+    }
+    .source-dialog::backdrop {
+      background: rgba(0, 0, 0, 0.5);
+    }
+    .source-dialog__header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 1rem 1.5rem;
+      border-bottom: 1px solid #e5e7eb;
+      background: #f9fafb;
+      border-radius: 12px 12px 0 0;
+    }
+    .source-dialog__title {
+      font-size: 1rem;
+      font-weight: 600;
+      color: #111827;
+    }
+    .source-dialog__close {
+      background: none;
+      border: none;
+      font-size: 1.5rem;
+      cursor: pointer;
+      color: #6b7280;
+      line-height: 1;
+      padding: 0.25rem;
+      border-radius: 4px;
+    }
+    .source-dialog__close:hover { color: #111827; }
+    .source-dialog__body {
+      padding: 1rem 1.5rem;
+      overflow-y: auto;
+      max-height: calc(80vh - 4rem);
+    }
+    .source-dialog__description {
+      font-size: 0.875rem;
+      color: #6b7280;
+      margin-bottom: 1rem;
+      line-height: 1.6;
+    }
+    .source-dialog__code-wrapper {
+      position: relative;
+    }
+    .source-dialog__code {
+      background: #1e293b;
+      color: #e2e8f0;
+      padding: 1rem;
+      border-radius: 8px;
+      font-size: 0.8125rem;
+      line-height: 1.6;
+      overflow-x: auto;
+      white-space: pre;
+      font-family: 'SF Mono', 'Fira Code', 'Fira Mono', Menlo, Consolas, monospace;
+    }
+    .source-dialog__copy {
+      position: absolute;
+      top: 0.5rem;
+      right: 0.5rem;
+      padding: 0.375rem 0.75rem;
+      background: rgba(255, 255, 255, 0.1);
+      color: #e2e8f0;
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      border-radius: 6px;
+      font-size: 0.75rem;
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+    .source-dialog__copy:hover { background: rgba(255, 255, 255, 0.2); }
+
+    .back-link {
+      position: fixed;
+      top: 0.75rem;
+      left: 0.75rem;
+      z-index: 1000;
+      padding: 0.5rem 1rem;
+      background: #fff;
+      color: #374151;
+      text-decoration: none;
+      border-radius: 8px;
+      font-size: 0.8125rem;
+      font-weight: 500;
+      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.15);
+      transition: box-shadow 0.15s;
+    }
+    .back-link:hover { box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2); }
+  </style>
+</head>
+<body>
+  <a class="back-link" href="./">&larr; Demos</a>
+
+  <!--
+    Geolonia Embed Plugin を使ったサンプルページ。
+    data-draw="on" を指定するだけで描画機能が有効になります。
+  -->
+  <div
+    id="map"
+    class="geolonia"
+    data-draw="on"
+    data-navigation-control="on"
+    data-style="geolonia/basic-v1"
+    data-lat="35.681"
+    data-lng="139.767"
+    data-zoom="14"
+    style="width: 100%; height: 100vh;"
+  ></div>
+
+  <button
+    class="view-source-button"
+    id="view-source-btn"
+    type="button"
+    aria-haspopup="dialog"
+  >ソースコードを見る</button>
+
+  <dialog class="source-dialog" id="source-dialog">
+    <div class="source-dialog__header">
+      <span class="source-dialog__title">HTML サンプルコード</span>
+      <button class="source-dialog__close" id="dialog-close" type="button" aria-label="閉じる">&times;</button>
+    </div>
+    <div class="source-dialog__body">
+      <p class="source-dialog__description">
+        以下のHTMLをコピーして、ご自身のプロジェクトに貼り付けてください。<br>
+        <code>YOUR-API-KEY</code> を実際の Geolonia API キーに置き換えてください。
+      </p>
+      <div class="source-dialog__code-wrapper">
+        <button class="source-dialog__copy" id="copy-btn" type="button">コピー</button>
+        <pre class="source-dialog__code" id="source-code"></pre>
+      </div>
+    </div>
+  </dialog>
+
+  <!-- Geolonia Embed API -->
+  <script src="https://cdn.geolonia.com/v1/embed?geolonia-api-key=%VITE_GEOLONIA_API_KEY%"></script>
+  <!-- Drawing Engine Plugin (IIFE build) -->
+  <link rel="stylesheet" href="https://cdn.geolonia.com/v1/draw-plugin/style.css">
+  <script src="https://cdn.geolonia.com/v1/draw-plugin/plugin.iife.js"></script>
+
+  <script>
+    // Source code display logic
+    (function() {
+      var sampleCode =
+'<!DOCTYPE html>\n' +
+'<html lang="ja">\n' +
+'<head>\n' +
+'  <meta charset="UTF-8">\n' +
+'  <meta name="viewport" content="width=device-width, initial-scale=1.0">\n' +
+'  <title>Drawing Engine Sample</title>\n' +
+'  <style>\n' +
+'    body { margin: 0; }\n' +
+'    #map { width: 100%; height: 100vh; }\n' +
+'  </style>\n' +
+'</head>\n' +
+'<body>\n' +
+'  <!--\n' +
+'    data-draw="on" を指定するだけで描画機能が有効になります。\n' +
+'  -->\n' +
+'  <div\n' +
+'    id="map"\n' +
+'    class="geolonia"\n' +
+'    data-draw="on"\n' +
+'    data-navigation-control="on"\n' +
+'    data-style="geolonia/basic-v1"\n' +
+'    data-lat="35.681"\n' +
+'    data-lng="139.767"\n' +
+'    data-zoom="14"\n' +
+'    style="width: 100%; height: 100vh;"\n' +
+'  ></div>\n' +
+'\n' +
+'  <!-- Geolonia Embed API -->\n' +
+'  <script src="https://cdn.geolonia.com/v1/embed?geolonia-api-key=YOUR-API-KEY"><\\/script>\n' +
+'  <!-- Drawing Engine Plugin -->\n' +
+'  <link rel="stylesheet" href="https://cdn.geolonia.com/v1/draw-plugin/style.css">\n' +
+'  <script src="https://cdn.geolonia.com/v1/draw-plugin/plugin.iife.js"><\\/script>\n' +
+'</body>\n' +
+'</html>';
+
+      var sourceCodeEl = document.getElementById('source-code');
+      var dialog = document.getElementById('source-dialog');
+      var viewSourceBtn = document.getElementById('view-source-btn');
+      var closeBtn = document.getElementById('dialog-close');
+      var copyBtn = document.getElementById('copy-btn');
+
+      // Escape HTML entities for safe display
+      function escapeHtml(text) {
+        var div = document.createElement('div');
+        div.appendChild(document.createTextNode(text));
+        return div.innerHTML;
+      }
+
+      sourceCodeEl.innerHTML = escapeHtml(sampleCode);
+
+      viewSourceBtn.addEventListener('click', function() {
+        dialog.showModal();
+      });
+
+      closeBtn.addEventListener('click', function() {
+        dialog.close();
+      });
+
+      dialog.addEventListener('click', function(e) {
+        if (e.target === dialog) {
+          dialog.close();
+        }
+      });
+
+      copyBtn.addEventListener('click', function() {
+        navigator.clipboard.writeText(sampleCode).then(function() {
+          var original = copyBtn.textContent;
+          copyBtn.textContent = 'コピーしました!';
+          setTimeout(function() {
+            copyBtn.textContent = original;
+          }, 2000);
+        });
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/preview/html-sample.html
+++ b/preview/html-sample.html
@@ -244,6 +244,14 @@
       });
 
       copyBtn.addEventListener('click', function() {
+        if (!navigator.clipboard || typeof navigator.clipboard.writeText !== 'function') {
+          var original = copyBtn.textContent;
+          copyBtn.textContent = 'コピー失敗';
+          setTimeout(function() {
+            copyBtn.textContent = original;
+          }, 2000);
+          return;
+        }
         navigator.clipboard.writeText(sampleCode).then(function() {
           var original = copyBtn.textContent;
           copyBtn.textContent = 'コピーしました!';

--- a/preview/html-sample.html
+++ b/preview/html-sample.html
@@ -250,6 +250,13 @@
           setTimeout(function() {
             copyBtn.textContent = original;
           }, 2000);
+        }).catch(function(err) {
+          console.error('クリップボードへのコピーに失敗しました:', err);
+          var original = copyBtn.textContent;
+          copyBtn.textContent = 'コピー失敗';
+          setTimeout(function() {
+            copyBtn.textContent = original;
+          }, 2000);
         });
       });
     })();

--- a/vite.config.preview.ts
+++ b/vite.config.preview.ts
@@ -48,6 +48,7 @@ export default defineConfig({
       input: {
         home: resolve(__dirname, 'preview/home.html'),
         index: resolve(__dirname, 'preview/index.html'),
+        'html-sample': resolve(__dirname, 'preview/html-sample.html'),
       },
     },
   },


### PR DESCRIPTION
Closes #20

## Summary

HTML（非 React）から drawing-engine を利用するサンプルページを作成し、ソースコード閲覧ボタンを追加。

## Changes

| ファイル | 変更内容 |
|---|---|
| `preview/html-sample.html` | HTML サンプルページ本体（地図 + ソースコード閲覧ダイアログ） |
| `preview/home.html` | デモ一覧に HTML Sample カードを追加 |
| `vite.config.preview.ts` | `rollupOptions.input` に `html-sample` を追加 |

## 実装詳細

- Geolonia Embed Plugin（`data-draw="on"`）を使った地図描画デモ
- ネイティブ `<dialog>` 要素でソースコード閲覧モーダルを実装
- 「コピー」ボタンで `navigator.clipboard` API によるワンクリックコピー（エラーハンドリング付き）
- `escapeHtml()` による XSS 対策済み
- `build:preview` でビルド・デプロイに対応

## 影響範囲

- preview のみの変更。ライブラリ本体への影響なし。

## Test plan

- [x] `npm run lint` パス
- [x] `npm run build` パス
- [x] `npm run build:preview` パス（`html-sample.html` が `dist-preview/` に出力）
- [x] `npm test` 全テストパス

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 新機能
- HTMLサンプルデモページを追加しました。Geolonia地図の描画機能を体験できます。
- デモページにソースコード表示ダイアログとクリップボードへコピーする機能を搭載しました（コピー可否のフィードバックあり）。
- デモナビゲーションから新しいHTMLサンプルへアクセス可能になりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->