### PR TITLE
feat: React デモサイトにサンプルコード閲覧ボタンを追加 (#21)

### DIFF
--- a/preview/App.tsx
+++ b/preview/App.tsx
@@ -6,6 +6,11 @@ import {
 } from '@geolonia/drawing-engine'
 import '@geolonia/drawing-engine/style.css'
 
+import { CodeViewer } from './CodeViewer'
+import './CodeViewer.css'
+// @ts-expect-error -- Vite ?raw import returns a string at build time
+import appSource from './App.tsx?raw'
+
 export function App() {
   const { containerRef, map } = useGeoloniaMap({
     center: [139.767, 35.681],
@@ -46,6 +51,7 @@ export function App() {
             )}
           </>
         )}
+        <CodeViewer code={appSource as string} fileName="App.tsx" />
       </div>
     </div>
   )

--- a/preview/App.tsx
+++ b/preview/App.tsx
@@ -8,7 +8,6 @@ import '@geolonia/drawing-engine/style.css'
 
 import { CodeViewer } from './CodeViewer'
 import './CodeViewer.css'
-// @ts-expect-error -- Vite ?raw import returns a string at build time
 import appSource from './App.tsx?raw'
 
 export function App() {
@@ -51,7 +50,7 @@ export function App() {
             )}
           </>
         )}
-        <CodeViewer code={appSource as string} fileName="App.tsx" />
+        <CodeViewer code={appSource} fileName="App.tsx" />
       </div>
     </div>
   )

--- a/preview/CodeViewer.css
+++ b/preview/CodeViewer.css
@@ -1,0 +1,118 @@
+/* ── Toggle button ── */
+.code-viewer__toggle {
+  position: absolute;
+  bottom: 1rem;
+  right: 1rem;
+  z-index: 20;
+  padding: 0.5rem 1rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  background: #fff;
+  color: #333;
+  font-size: 0.8125rem;
+  font-family: inherit;
+  cursor: pointer;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    box-shadow 0.15s;
+}
+
+.code-viewer__toggle:hover,
+.code-viewer__toggle:focus-visible {
+  border-color: #3b82f6;
+  box-shadow: 0 2px 8px rgba(59, 130, 246, 0.15);
+}
+
+/* ── Slide-in panel ── */
+.code-viewer__panel {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(480px, 100%);
+  z-index: 30;
+  display: flex;
+  flex-direction: column;
+  background: #1e1e2e;
+  box-shadow: -4px 0 16px rgba(0, 0, 0, 0.25);
+  animation: code-viewer-slide-in 0.2s ease-out;
+}
+
+@keyframes code-viewer-slide-in {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+/* ── Header ── */
+.code-viewer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.625rem 1rem;
+  background: #181825;
+  border-bottom: 1px solid #313244;
+}
+
+.code-viewer__filename {
+  font-size: 0.8125rem;
+  color: #cdd6f4;
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', Menlo, Consolas, monospace;
+}
+
+.code-viewer__close {
+  background: none;
+  border: none;
+  color: #a6adc8;
+  font-size: 1.25rem;
+  cursor: pointer;
+  padding: 0 0.25rem;
+  line-height: 1;
+}
+
+.code-viewer__close:hover {
+  color: #f38ba8;
+}
+
+/* ── Code block ── */
+.code-viewer__pre {
+  flex: 1;
+  margin: 0;
+  padding: 1rem;
+  overflow: auto;
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  tab-size: 2;
+}
+
+.code-viewer__code {
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', Menlo, Consolas, monospace;
+  color: #cdd6f4;
+}
+
+/* ── Syntax highlight tokens (Catppuccin-inspired) ── */
+.hl-keyword {
+  color: #cba6f7;
+}
+
+.hl-string {
+  color: #a6e3a1;
+}
+
+.hl-comment {
+  color: #6c7086;
+  font-style: italic;
+}
+
+.hl-tag {
+  color: #89b4fa;
+}
+
+.hl-number {
+  color: #fab387;
+}

--- a/preview/CodeViewer.css
+++ b/preview/CodeViewer.css
@@ -116,3 +116,9 @@
 .hl-number {
   color: #fab387;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .code-viewer__panel {
+    animation: none;
+  }
+}

--- a/preview/CodeViewer.tsx
+++ b/preview/CodeViewer.tsx
@@ -1,0 +1,144 @@
+import { useState, useCallback } from 'react'
+
+interface CodeViewerProps {
+  code: string
+  fileName: string
+}
+
+/**
+ * A lightweight code viewer panel with CSS-based syntax highlighting for TSX.
+ * Shows/hides with a toggle button.
+ */
+export function CodeViewer({ code, fileName }: CodeViewerProps) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const toggle = useCallback(() => {
+    setIsOpen((prev) => !prev)
+  }, [])
+
+  return (
+    <>
+      <button
+        type="button"
+        className="code-viewer__toggle"
+        onClick={toggle}
+        aria-expanded={isOpen}
+        aria-controls="code-viewer-panel"
+      >
+        {isOpen ? 'Hide Source' : 'View Source'}
+      </button>
+
+      {isOpen && (
+        <div
+          id="code-viewer-panel"
+          className="code-viewer__panel"
+          role="region"
+          aria-label="Source code viewer"
+        >
+          <div className="code-viewer__header">
+            <span className="code-viewer__filename">{fileName}</span>
+            <button
+              type="button"
+              className="code-viewer__close"
+              onClick={toggle}
+              aria-label="Close source code viewer"
+            >
+              &times;
+            </button>
+          </div>
+          <pre className="code-viewer__pre">
+            <code
+              className="code-viewer__code"
+              dangerouslySetInnerHTML={{ __html: highlightTsx(code) }}
+            />
+          </pre>
+        </div>
+      )}
+    </>
+  )
+}
+
+/** Escape HTML special characters. */
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+const KEYWORDS = new Set([
+  'import', 'export', 'from', 'const', 'let', 'var', 'function', 'return',
+  'if', 'else', 'new', 'true', 'false', 'null', 'undefined', 'typeof',
+  'void', 'class', 'extends', 'default', 'throw', 'try', 'catch', 'finally',
+  'async', 'await', 'yield', 'interface', 'type', 'as', 'readonly', 'keyof',
+  'infer', 'enum',
+])
+
+/**
+ * Lightweight TSX syntax highlighter using a single-pass tokeniser.
+ * Produces HTML with `<span class="hl-*">` wrappers for CSS-based colouring.
+ *
+ * This is intentionally simple -- it covers the common patterns found in
+ * React demo code without pulling in a heavy highlighting library.
+ */
+function highlightTsx(source: string): string {
+  // Combined regex that matches tokens in priority order.
+  // The first matching group wins, so earlier alternatives take precedence.
+  const tokenRe =
+    /(\/\/[^\n]*)|(\/\*[\s\S]*?\*\/)|(`(?:[^`\\]|\\.)*`)|("(?:[^"\\]|\\.)*")|('(?:[^'\\]|\\.)*')|(<\/?[A-Z][\w.]*)|\b(\d+(?:\.\d+)?)\b|\b([a-zA-Z_$][\w$]*)\b/g
+
+  const parts: string[] = []
+  let lastIndex = 0
+  let match: RegExpExecArray | null
+
+  while ((match = tokenRe.exec(source)) !== null) {
+    // Append any text between the previous match and this one
+    if (match.index > lastIndex) {
+      parts.push(escapeHtml(source.slice(lastIndex, match.index)))
+    }
+
+    const [
+      fullMatch,
+      lineComment,
+      blockComment,
+      templateLiteral,
+      doubleString,
+      singleString,
+      jsxTag,
+      number,
+      identifier,
+    ] = match
+
+    if (lineComment !== undefined || blockComment !== undefined) {
+      parts.push(`<span class="hl-comment">${escapeHtml(fullMatch)}</span>`)
+    } else if (
+      templateLiteral !== undefined ||
+      doubleString !== undefined ||
+      singleString !== undefined
+    ) {
+      parts.push(`<span class="hl-string">${escapeHtml(fullMatch)}</span>`)
+    } else if (jsxTag !== undefined) {
+      parts.push(`<span class="hl-tag">${escapeHtml(fullMatch)}</span>`)
+    } else if (number !== undefined) {
+      parts.push(`<span class="hl-number">${escapeHtml(fullMatch)}</span>`)
+    } else if (identifier !== undefined) {
+      if (KEYWORDS.has(identifier)) {
+        parts.push(`<span class="hl-keyword">${escapeHtml(fullMatch)}</span>`)
+      } else {
+        parts.push(escapeHtml(fullMatch))
+      }
+    } else {
+      parts.push(escapeHtml(fullMatch))
+    }
+
+    lastIndex = match.index + fullMatch.length
+  }
+
+  // Append remaining text
+  if (lastIndex < source.length) {
+    parts.push(escapeHtml(source.slice(lastIndex)))
+  }
+
+  return parts.join('')
+}

--- a/preview/CodeViewer.tsx
+++ b/preview/CodeViewer.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 
 interface CodeViewerProps {
   code: string
@@ -15,6 +15,19 @@ export function CodeViewer({ code, fileName }: CodeViewerProps) {
   const toggle = useCallback(() => {
     setIsOpen((prev) => !prev)
   }, [])
+
+  useEffect(() => {
+    if (!isOpen) return
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setIsOpen(false)
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [isOpen])
 
   return (
     <>

--- a/preview/CodeViewer.tsx
+++ b/preview/CodeViewer.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback, useEffect, useId } from 'react'
 
 interface CodeViewerProps {
   code: string
@@ -10,6 +10,7 @@ interface CodeViewerProps {
  * Shows/hides with a toggle button.
  */
 export function CodeViewer({ code, fileName }: CodeViewerProps) {
+  const panelId = useId()
   const [isOpen, setIsOpen] = useState(false)
 
   const toggle = useCallback(() => {
@@ -36,14 +37,14 @@ export function CodeViewer({ code, fileName }: CodeViewerProps) {
         className="code-viewer__toggle"
         onClick={toggle}
         aria-expanded={isOpen}
-        aria-controls="code-viewer-panel"
+        aria-controls={panelId}
       >
         {isOpen ? 'Hide Source' : 'View Source'}
       </button>
 
       {isOpen && (
         <div
-          id="code-viewer-panel"
+          id={panelId}
           className="code-viewer__panel"
           role="region"
           aria-label="Source code viewer"
@@ -94,6 +95,10 @@ const KEYWORDS = new Set([
  *
  * This is intentionally simple -- it covers the common patterns found in
  * React demo code without pulling in a heavy highlighting library.
+ *
+ * **Safety**: Input is expected to be trusted, build-time embedded source code
+ * (e.g. Vite `?raw` imports). All output is passed through {@link escapeHtml}
+ * before injection via `dangerouslySetInnerHTML`.
  */
 function highlightTsx(source: string): string {
   // Combined regex that matches tokens in priority order.

--- a/preview/vite-env.d.ts
+++ b/preview/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
Closes #21

## Summary

既存の React デモサイト（`preview/`）に「View Source」ボタンとソースコード閲覧パネルを追加。

## Changes

| ファイル | 変更内容 |
|---|---|
| `preview/CodeViewer.tsx` | コードビューアコンポーネント（シンタックスハイライト付き） |
| `preview/CodeViewer.css` | コードビューアのスタイル（Catppuccin 風ダークテーマ） |
| `preview/App.tsx` | CodeViewer コンポーネントを統合、`?raw` で自身のソースを読み込み |
| `preview/vite-env.d.ts` | Vite クライアント型定義（`?raw` インポートの型サポート） |

## 実装詳細

- 右下の「View Source」ボタンでスライドインパネルを表示/非表示
- Vite の `?raw` import で `App.tsx` のソースコードをビルド時に埋め込み
- 外部依存なしの CSS ベースシンタックスハイライト（キーワード、文字列、JSX タグ等）
- アクセシビリティ対応: `aria-expanded`, `aria-controls`, Escape キーで閉じる, `prefers-reduced-motion`
- 既存 UI パターンとの統一（青系アクセントカラー、フォントファミリー）

## 影響範囲

- preview のみの変更。ライブラリ本体への影響なし。

## Test plan

- [x] `npm run lint` パス
- [x] `npm run build` パス
- [x] `npm run build:preview` パス
- [x] `npm test` 全テストパス

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ソースコードを表示するコードビューアーを追加しました。
  * ファイル名表示付きのスライドインパネルでソースを閲覧できます。
  * シンタックスハイライトでコードの可読性を向上しました。
  * トグルボタン、クローズ操作、または Escキーで表示/非表示を切り替え可能です。
  * ユーザーの「減速モーション」設定を考慮します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->